### PR TITLE
Add volatile to inline asm. 

### DIFF
--- a/riscv-example/src/startup.c
+++ b/riscv-example/src/startup.c
@@ -7,25 +7,25 @@ extern uint8_t _sdata;
 extern uint8_t _esdata;
 
 // Adapted from https://stackoverflow.com/questions/58947716/how-to-interact-with-risc-v-csrs-by-using-gcc-c-code
-__attribute__((always_inline)) uint32_t csr_mstatus_read(void){
+__attribute__((always_inline)) inline uint32_t csr_mstatus_read(void){
     uint32_t result;
     asm("csrr %0, mstatus" : "=r"(result));
     return result;
 }
 
-__attribute__((always_inline)) void csr_mstatus_write(uint32_t val){
+__attribute__((always_inline)) inline void csr_mstatus_write(uint32_t val){
     asm("csrw mstatus, %0" : "=r"(val));
 }
 
-__attribute__((always_inline)) void csr_write_mie(uint32_t val){
+__attribute__((always_inline)) inline void csr_write_mie(uint32_t val){
     asm("csrw mie, %0" : "=r"(val));
 }
 
-__attribute__((always_inline)) void csr_enable_interrupts(void){
+__attribute__((always_inline)) inline void csr_enable_interrupts(void){
     asm("csrsi mstatus, 0x8");
 }
 
-__attribute__((always_inline)) void csr_disable_interrupts(void){
+__attribute__((always_inline)) inline void csr_disable_interrupts(void){
     asm("csrci mstatus, 0x8");
 }
 

--- a/riscv-example/src/startup.c
+++ b/riscv-example/src/startup.c
@@ -14,11 +14,11 @@ __attribute__((always_inline)) inline uint32_t csr_mstatus_read(void){
 }
 
 __attribute__((always_inline)) inline void csr_mstatus_write(uint32_t val){
-    asm volatile ("csrw mstatus, %0" : "=r"(val));
+    asm volatile ("csrw mstatus, %0" : : "r"(val));
 }
 
 __attribute__((always_inline)) inline void csr_write_mie(uint32_t val){
-    asm volatile ("csrw mie, %0" : "=r"(val));
+    asm volatile ("csrw mie, %0" : : "r"(val));
 }
 
 __attribute__((always_inline)) inline void csr_enable_interrupts(void){

--- a/riscv-example/src/startup.c
+++ b/riscv-example/src/startup.c
@@ -9,24 +9,24 @@ extern uint8_t _esdata;
 // Adapted from https://stackoverflow.com/questions/58947716/how-to-interact-with-risc-v-csrs-by-using-gcc-c-code
 __attribute__((always_inline)) inline uint32_t csr_mstatus_read(void){
     uint32_t result;
-    asm("csrr %0, mstatus" : "=r"(result));
+    asm volatile ("csrr %0, mstatus" : "=r"(result));
     return result;
 }
 
 __attribute__((always_inline)) inline void csr_mstatus_write(uint32_t val){
-    asm("csrw mstatus, %0" : "=r"(val));
+    asm volatile ("csrw mstatus, %0" : "=r"(val));
 }
 
 __attribute__((always_inline)) inline void csr_write_mie(uint32_t val){
-    asm("csrw mie, %0" : "=r"(val));
+    asm volatile ("csrw mie, %0" : "=r"(val));
 }
 
 __attribute__((always_inline)) inline void csr_enable_interrupts(void){
-    asm("csrsi mstatus, 0x8");
+    asm volatile ("csrsi mstatus, 0x8");
 }
 
 __attribute__((always_inline)) inline void csr_disable_interrupts(void){
-    asm("csrci mstatus, 0x8");
+    asm volatile ("csrci mstatus, 0x8");
 }
 
 #define MTIME_LOW       (*((volatile uint32_t *)0x40000008))


### PR DESCRIPTION
This PR makes sure inline assembly instructions are not optimized out.
Related: https://stackoverflow.com/questions/65767492/prevent-risc-v-inline-assembly-instruction-being-optimized-out-in-gcc-o3?noredirect=1#comment116280802_65767492

Also, here `val` is placed in output list, but it should be in input:

    asm("csrw mstatus, %0" : "=r"(val));

So it should be:

    asm volatile ("csrw mstatus, %0" : : "r"(val));