### PR TITLE
Add `.sbss` to linking script

### DIFF
--- a/riscv-example/riscv32-console.ld
+++ b/riscv-example/riscv32-console.ld
@@ -65,6 +65,7 @@ SECTIONS
     {
         _bss = .;           /* beginning of .bss segment */
         *(.bss*)            /* .bss content goes here */
+        *(.sbss*)           /* .sbss content goes here */
         *(COMMON)       
         . = ALIGN(. != 0 ? 32 / 8 : 1);
         _ebss = .;          /* end of .bss segment */


### PR DESCRIPTION
Sometimes the compiled program contains a `.sbss` section, which is not linked in the ld script. 