### PR TITLE
Support scaling video controller output by an integer

### DIFF
--- a/riscv-sim/Makefile
+++ b/riscv-sim/Makefile
@@ -17,6 +17,10 @@ BIN_DIR = ./bin
 
 PKGS = gtk+-3.0 
 
+SCALE = 1
+
+CFLAGS   += -DVIDEO_SCALE=$(SCALE)
+
 ifdef DEBUG_MODE
 DEFINES  += -DDEBUG
 CFLAGS   += -g -ggdb -D_GLIBCXX_DEBUG

--- a/riscv-sim/src/RISCVConsoleApplication.cpp
+++ b/riscv-sim/src/RISCVConsoleApplication.cpp
@@ -462,6 +462,10 @@ void CRISCVConsoleApplication::CreateConsoleWidgets(){
     DControlsBox->PackStart(DControllerGrid,false,false,GetWidgetSpacing());
     DControlsBox->PackStart(DSystemControlGrid,false,false,GetWidgetSpacing());
 
+    // Center the buttons
+    DControllerGrid->SetHorizontalExpand(true);
+    DSystemControlGrid->SetHorizontalExpand(true);
+
     DConsoleBox->PackStart(DConsoleVideo,false,false,GetWidgetSpacing());
     DConsoleBox->PackStart(DControlsBox,false,false,GetWidgetSpacing());
     

--- a/riscv-sim/src/RISCVConsoleApplication.cpp
+++ b/riscv-sim/src/RISCVConsoleApplication.cpp
@@ -465,14 +465,14 @@ void CRISCVConsoleApplication::CreateConsoleWidgets(){
     DConsoleBox->PackStart(DConsoleVideo,false,false,GetWidgetSpacing());
     DConsoleBox->PackStart(DControlsBox,false,false,GetWidgetSpacing());
     
-    DDoubleBufferSurface = CGraphicFactory::CreateSurface(DRISCVConsole->ScreenWidth(), DRISCVConsole->ScreenHeight(), ESurfaceFormat::ARGB32);
-    DWorkingBufferSurface = CGraphicFactory::CreateSurface(DRISCVConsole->ScreenWidth(), DRISCVConsole->ScreenHeight(), ESurfaceFormat::ARGB32);
-    DConsoleVideo->SetSizeRequest(DRISCVConsole->ScreenWidth(), DRISCVConsole->ScreenHeight());
+    DDoubleBufferSurface = CGraphicFactory::CreateSurface(DRISCVConsole->ScreenWidth() * VIDEO_SCALE, DRISCVConsole->ScreenHeight() * VIDEO_SCALE, ESurfaceFormat::ARGB32);
+    DWorkingBufferSurface = CGraphicFactory::CreateSurface(DRISCVConsole->ScreenWidth() * VIDEO_SCALE, DRISCVConsole->ScreenHeight() * VIDEO_SCALE, ESurfaceFormat::ARGB32);
+    DConsoleVideo->SetSizeRequest(DRISCVConsole->ScreenWidth() * VIDEO_SCALE, DRISCVConsole->ScreenHeight() * VIDEO_SCALE);
     DConsoleVideo->SetDrawEventCallback(this, DrawingAreaDrawCallback);
     auto TempRC = DDoubleBufferSurface->CreateResourceContext();
     TempRC->SetSourceRGB(0x0);
     TempRC->SetLineWidth(1);
-    TempRC->Rectangle(0,0,DRISCVConsole->ScreenWidth(), DRISCVConsole->ScreenHeight());
+    TempRC->Rectangle(0,0,DRISCVConsole->ScreenWidth() * VIDEO_SCALE, DRISCVConsole->ScreenHeight() * VIDEO_SCALE);
     TempRC->StrokePreserve();
     TempRC->Fill();    
     DConsoleVideo->Invalidate();


### PR DESCRIPTION
When working with the riscv-console simulator on my laptop, I find the simulator window too small for me to read the text etc. So this PR allows the user to scale the video controller output at compile time.

By default, when the user runs `make`, everything still works as it used to be. If the user sets Makefile variable `SCALE` to 2 (e.g. using `make SCALE=2`), then each pixel in the game console will become a 2x2 pixel on the computer screen. Both the text mode and the graphics mode support this change.

After scaling the video controller, I came up with 2 ways to layout the ControlsBox.
* Layout A: the ControlsBox aligns to the left
    * ![图片](https://user-images.githubusercontent.com/9337403/113518203-b490e000-9539-11eb-9104-d8cf92f042d9.png)
    * ![图片](https://user-images.githubusercontent.com/9337403/113518181-8ca17c80-9539-11eb-83a1-8eb7fb5c78ec.png)
    * ![图片](https://user-images.githubusercontent.com/9337403/113518188-9aef9880-9539-11eb-95e6-f1eabba0d667.png)
* Layout B: each widget in the ControlsBox aligns to the center
    * ![图片](https://user-images.githubusercontent.com/9337403/113518169-6bd92700-9539-11eb-88ff-74cacaade4c2.png)
    * ![图片](https://user-images.githubusercontent.com/9337403/113518159-506e1c00-9539-11eb-99ad-b4559bf88f81.png)

This PR is using Layout B. To revert to Layout A simply remote these 3 lines in `src/RISCVConsoleApplication.cpp`:
```c++
    // Center the buttons
    DControllerGrid->SetHorizontalExpand(true);
    DSystemControlGrid->SetHorizontalExpand(true);
```

It is possible to implement other layouts. However more changes to the code may be required.

Tested on Linux (Fedora 33, GNome 3.38, Xorg), using a screen size 1920x1080.

Video Demo:

https://user-images.githubusercontent.com/9337403/113521059-f0cd3c00-954b-11eb-907a-1daa666e2e30.mp4
