### PR TITLE
Draft: Add Simple Memory Watchpoints 

### DIFF
--- a/riscv-sim/Makefile
+++ b/riscv-sim/Makefile
@@ -53,6 +53,7 @@ SIM_APP_OBJS = $(OBJ_DIR)/main.o                \
     $(OBJ_DIR)/Path.o                           \
     $(OBJ_DIR)/MemoryControllerDevice.o         \
     $(OBJ_DIR)/MemoryDevice.o                   \
+    $(OBJ_DIR)/MemoryRange.o                    \
     $(OBJ_DIR)/FlashMemoryDevice.o              \
     $(OBJ_DIR)/RAMMemoryDevice.o                \
     $(OBJ_DIR)/RegisterBlockMemoryDevice.o      \
@@ -82,6 +83,7 @@ AUTO_RUN_APP_OBJS = $(OBJ_DIR)/autorunmain.o    \
     $(OBJ_DIR)/Path.o                           \
     $(OBJ_DIR)/MemoryControllerDevice.o         \
     $(OBJ_DIR)/MemoryDevice.o                   \
+    $(OBJ_DIR)/MemoryRange.o                    \
     $(OBJ_DIR)/FlashMemoryDevice.o              \
     $(OBJ_DIR)/RAMMemoryDevice.o                \
     $(OBJ_DIR)/RegisterBlockMemoryDevice.o      \

--- a/riscv-sim/include/GUIScrollableMemoryLabelBox.h
+++ b/riscv-sim/include/GUIScrollableMemoryLabelBox.h
@@ -44,6 +44,9 @@ class CGUIScrollableMemoryLabelBox : public CGUIScrollableLabelBox{
 
         virtual void Refresh();
 
+	size_t AddressToMemoryIndex(uint32_t addr) const;
+
+	uint32_t AddressMemoryIndexToLineBytes(uint32_t addr, size_t mem_index) const;
 };
 
 #endif

--- a/riscv-sim/include/GUIScrollableMemoryLabelBox.h
+++ b/riscv-sim/include/GUIScrollableMemoryLabelBox.h
@@ -21,7 +21,7 @@ class CGUIScrollableMemoryLabelBox : public CGUIScrollableLabelBox{
         virtual void UpdateBaseLine();
         virtual void RefreshLabels() override;
         virtual void UpdateMemoryLine(size_t index, uint32_t addr, uint32_t bytes);
-        static std::string FormatMemoryLine(const uint8_t *buffer, uint32_t addr, uint32_t bytes);
+        std::string FormatMemoryLine(const uint8_t *buffer, uint32_t addr, uint32_t bytes) const;
 
     public:
         CGUIScrollableMemoryLabelBox(std::shared_ptr< CMemoryDevice > device, const std::unordered_map< uint32_t, uint32_t > &regions, size_t initsize=8);

--- a/riscv-sim/include/GUIScrollableMemoryLabelBox.h
+++ b/riscv-sim/include/GUIScrollableMemoryLabelBox.h
@@ -29,6 +29,7 @@ class CGUIScrollableMemoryLabelBox : public CGUIScrollableLabelBox{
 
         virtual uint32_t GetBaseAddress();
         virtual void SetBaseAddress(uint32_t addr, bool ascending);
+	void SetBaseAddress(uint32_t watchpoint_address);
 
         virtual bool GetAddressAscending() const;
 

--- a/riscv-sim/include/MemoryControllerDevice.h
+++ b/riscv-sim/include/MemoryControllerDevice.h
@@ -15,8 +15,11 @@ class CMemoryControllerDevice : public CMemoryDevice{
         std::shared_ptr<CMemoryDevice> AccessAddress(uint32_t addr, uint32_t size, bool debug_load=false);
 
 	std::set< CMemoryRange > DWatchpoints;
+
+	uint32_t *WatchpointAddress;
+	bool *WatchpointHit;
     public:
-        CMemoryControllerDevice(uint32_t bits);
+        CMemoryControllerDevice(uint32_t bits, uint32_t *watchpoint_address, bool *watchpoint_hit);
         virtual ~CMemoryControllerDevice(){};
         virtual void DumpData(std::ostream &out, uint32_t saddr=0, uint32_t eaddr=0);
         virtual bool AttachDevice(std::shared_ptr< CMemoryDevice > device, uint32_t addr);

--- a/riscv-sim/include/MemoryControllerDevice.h
+++ b/riscv-sim/include/MemoryControllerDevice.h
@@ -45,6 +45,7 @@ class CMemoryControllerDevice : public CMemoryDevice{
         virtual const uint8_t *LoadData(uint32_t addr, uint32_t size);
         virtual void StoreData(uint32_t addr, const uint8_t *src, uint32_t size);
 
+        void ClearWatchpoints();
         void AddWatchpoint(CMemoryRange mem_range);
         void RemoveWatchpoint(CMemoryRange mem_range);
 };

--- a/riscv-sim/include/MemoryControllerDevice.h
+++ b/riscv-sim/include/MemoryControllerDevice.h
@@ -49,6 +49,10 @@ class CMemoryControllerDevice : public CMemoryDevice{
         void AddWatchpoint(CMemoryRange mem_range);
         void RemoveWatchpoint(CMemoryRange mem_range);
         bool FindWatchpoint(CMemoryRange mem_range) const;
+
+	const std::set< CMemoryRange > &Watchpoints() const{
+	    return DWatchpoints;
+	};
 };
 
 #endif

--- a/riscv-sim/include/MemoryControllerDevice.h
+++ b/riscv-sim/include/MemoryControllerDevice.h
@@ -12,7 +12,7 @@ class CMemoryControllerDevice : public CMemoryDevice{
         uint32_t DShiftBits;
         std::vector< std::shared_ptr<CMemoryDevice> > DSubDevices;
 
-        std::shared_ptr<CMemoryDevice> AccessAddress(uint32_t addr, uint32_t size);
+        std::shared_ptr<CMemoryDevice> AccessAddress(uint32_t addr, uint32_t size, bool debug_load=false);
 
 	std::set< CMemoryRange > DWatchpoints;
     public:

--- a/riscv-sim/include/MemoryControllerDevice.h
+++ b/riscv-sim/include/MemoryControllerDevice.h
@@ -2,6 +2,8 @@
 #define MEMORYCONTROLLERDEVICE_H
 
 #include "MemoryDevice.h"
+#include "MemoryRange.h"
+#include <set>
 
 class CMemoryControllerDevice : public CMemoryDevice{
     protected:
@@ -12,6 +14,7 @@ class CMemoryControllerDevice : public CMemoryDevice{
 
         std::shared_ptr<CMemoryDevice> AccessAddress(uint32_t addr, uint32_t size);
 
+	std::set< CMemoryRange > DWatchpoints;
     public:
         CMemoryControllerDevice(uint32_t bits);
         virtual ~CMemoryControllerDevice(){};
@@ -41,6 +44,9 @@ class CMemoryControllerDevice : public CMemoryDevice{
 
         virtual const uint8_t *LoadData(uint32_t addr, uint32_t size);
         virtual void StoreData(uint32_t addr, const uint8_t *src, uint32_t size);
+
+        void AddWatchpoint(CMemoryRange mem_range);
+        void RemoveWatchpoint(CMemoryRange mem_range);
 };
 
 #endif

--- a/riscv-sim/include/MemoryControllerDevice.h
+++ b/riscv-sim/include/MemoryControllerDevice.h
@@ -48,6 +48,7 @@ class CMemoryControllerDevice : public CMemoryDevice{
         void ClearWatchpoints();
         void AddWatchpoint(CMemoryRange mem_range);
         void RemoveWatchpoint(CMemoryRange mem_range);
+        bool FindWatchpoint(CMemoryRange mem_range) const;
 };
 
 #endif

--- a/riscv-sim/include/MemoryRange.h
+++ b/riscv-sim/include/MemoryRange.h
@@ -1,0 +1,13 @@
+#ifndef MEMORYRANGE_H
+#define MEMORYRANGE_H
+
+#include <stdint.h>
+
+class CMemoryRange{
+    public:
+        uint32_t addr;
+	uint32_t range;
+	bool operator<(const CMemoryRange & rhs) const;
+};
+
+#endif

--- a/riscv-sim/include/RISCVConsole.h
+++ b/riscv-sim/include/RISCVConsole.h
@@ -75,6 +75,8 @@ class CRISCVConsole{
         CRISCVConsoleBreakpointCalldata DBreakpointCalldata;
         CRISCVConsoleBreakpointCallback DBreakpointCallback;
 
+	bool WatchpointHit;
+	uint32_t WatchpointAddress;
 
         static const uint32_t DMainMemorySize;
         static const uint32_t DMainMemoryBase;

--- a/riscv-sim/include/RISCVConsole.h
+++ b/riscv-sim/include/RISCVConsole.h
@@ -165,6 +165,8 @@ class CRISCVConsole{
 
         void RemoveBreakpoint(uint32_t addr);
 
+        uint32_t GetWatchPointAddress();
+
         void SetWatchpointCallback(CRISCVConsoleWatchpointCalldata calldata, CRISCVConsoleWatchpointCallback callback);
 
         void SetBreakcpointCallback(CRISCVConsoleBreakpointCalldata calldata, CRISCVConsoleBreakpointCallback callback);

--- a/riscv-sim/include/RISCVConsole.h
+++ b/riscv-sim/include/RISCVConsole.h
@@ -18,6 +18,9 @@
 using CRISCVConsoleBreakpointCalldata = void *;
 using CRISCVConsoleBreakpointCallback = void (*)(CRISCVConsoleBreakpointCalldata);
 
+using CRISCVConsoleWatchpointCalldata = void *;
+using CRISCVConsoleWatchpointCallback = void (*)(CRISCVConsoleWatchpointCalldata);
+
 class CRISCVConsole{
     public:
         enum class EDirection : uint32_t {Left = 0x1, Up = 0x2, Down = 0x4, Right = 0x8};
@@ -77,6 +80,9 @@ class CRISCVConsole{
 
 	bool WatchpointHit;
 	uint32_t WatchpointAddress;
+
+	CRISCVConsoleWatchpointCalldata DWatchpointCalldata;
+	CRISCVConsoleWatchpointCallback DWatchpointCallback;
 
         static const uint32_t DMainMemorySize;
         static const uint32_t DMainMemoryBase;
@@ -158,6 +164,8 @@ class CRISCVConsole{
         void AddBreakpoint(uint32_t addr);
 
         void RemoveBreakpoint(uint32_t addr);
+
+        void SetWatchpointCallback(CRISCVConsoleWatchpointCalldata calldata, CRISCVConsoleWatchpointCallback callback);
 
         void SetBreakcpointCallback(CRISCVConsoleBreakpointCalldata calldata, CRISCVConsoleBreakpointCallback callback);
 

--- a/riscv-sim/include/RISCVConsole.h
+++ b/riscv-sim/include/RISCVConsole.h
@@ -5,6 +5,7 @@
 #include "RISCVConsoleChipset.h"
 #include "ElfLoad.h"
 #include "MemoryDevice.h"
+#include "MemoryRange.h"
 #include "FlashMemoryDevice.h"
 #include "VideoController.h"
 #include "DataSource.h"
@@ -147,6 +148,10 @@ class CRISCVConsole{
         uint64_t InsertCartridge(std::shared_ptr< CDataSource > elfsrc);
 
         uint64_t RemoveCartridge();
+
+        void AddWatchpoint(CMemoryRange range);
+
+        void RemoveWatchpoint(CMemoryRange range);
 
         void AddBreakpoint(uint32_t addr);
 

--- a/riscv-sim/include/RISCVConsoleApplication.h
+++ b/riscv-sim/include/RISCVConsoleApplication.h
@@ -122,6 +122,7 @@ class CRISCVConsoleApplication : public std::enable_shared_from_this<CRISCVConso
         static bool InstructionBoxButtonEventCallback(std::shared_ptr<CGUIScrollableLineBox> widget, SGUIButtonEvent &event, size_t line, TGUICalldata data);
         static bool InstructionBoxScrollEventCallback(std::shared_ptr<CGUIScrollableLineBox> widget, TGUICalldata data);
         static void BreakpointEventCallback(CRISCVConsoleBreakpointCalldata data);
+        static bool MemoryBoxButtonEventCallback(std::shared_ptr<CGUIScrollableLineBox> widget, SGUIButtonEvent &event, size_t line, TGUICalldata data);
 
         void Activate();
         bool Timeout();

--- a/riscv-sim/include/RISCVConsoleApplication.h
+++ b/riscv-sim/include/RISCVConsoleApplication.h
@@ -122,6 +122,7 @@ class CRISCVConsoleApplication : public std::enable_shared_from_this<CRISCVConso
         static bool InstructionBoxButtonEventCallback(std::shared_ptr<CGUIScrollableLineBox> widget, SGUIButtonEvent &event, size_t line, TGUICalldata data);
         static bool InstructionBoxScrollEventCallback(std::shared_ptr<CGUIScrollableLineBox> widget, TGUICalldata data);
         static void BreakpointEventCallback(CRISCVConsoleBreakpointCalldata data);
+        static void WatchpointEventCallback(CRISCVConsoleWatchpointCalldata data);
         static bool MemoryBoxButtonEventCallback(std::shared_ptr<CGUIScrollableLineBox> widget, SGUIButtonEvent &event, size_t line, TGUICalldata data);
 
         void Activate();
@@ -152,6 +153,7 @@ class CRISCVConsoleApplication : public std::enable_shared_from_this<CRISCVConso
         bool InstructionBoxButtonEvent(std::shared_ptr<CGUIScrollableLineBox> widget, SGUIButtonEvent &event, size_t line);
         bool InstructionBoxScrollEvent(std::shared_ptr<CGUIScrollableLineBox> widget);
         void BreakpointEvent();
+        void WatchpointEvent();
         bool MemoryBoxButtonEvent(std::shared_ptr<CGUIScrollableLineBox> widget, SGUIButtonEvent &event, size_t line);
 
         void CreateConsoleWidgets();

--- a/riscv-sim/include/RISCVConsoleApplication.h
+++ b/riscv-sim/include/RISCVConsoleApplication.h
@@ -166,6 +166,7 @@ class CRISCVConsoleApplication : public std::enable_shared_from_this<CRISCVConso
         void CreateDebugMemoryWidgets();
 
         bool ParseInstructionLine(size_t line, uint32_t &addr, bool &breakpoint);
+        bool ParseMemoryLine(size_t line, uint32_t &addr, bool &breakpoint);
 
         void SetKeyControllerMapping(const std::string &label, std::shared_ptr<CGUIToggleButton> button);
         void SetKeyZoomMapping(const std::string &keys, bool zoomin);

--- a/riscv-sim/include/RISCVConsoleApplication.h
+++ b/riscv-sim/include/RISCVConsoleApplication.h
@@ -152,6 +152,7 @@ class CRISCVConsoleApplication : public std::enable_shared_from_this<CRISCVConso
         bool InstructionBoxButtonEvent(std::shared_ptr<CGUIScrollableLineBox> widget, SGUIButtonEvent &event, size_t line);
         bool InstructionBoxScrollEvent(std::shared_ptr<CGUIScrollableLineBox> widget);
         void BreakpointEvent();
+        bool MemoryBoxButtonEvent(std::shared_ptr<CGUIScrollableLineBox> widget, SGUIButtonEvent &event, size_t line);
 
         void CreateConsoleWidgets();
         void CreateControllerWidgets();

--- a/riscv-sim/src/GUIScrollableMemoryLabelBox.cpp
+++ b/riscv-sim/src/GUIScrollableMemoryLabelBox.cpp
@@ -1,4 +1,6 @@
 #include "GUIScrollableMemoryLabelBox.h"
+#include "MemoryControllerDevice.h"
+#include "MemoryRange.h"
 #include <algorithm>
 #include <sstream>
 #include <iomanip>
@@ -117,7 +119,11 @@ void CGUIScrollableMemoryLabelBox::UpdateMemoryLine(size_t index, uint32_t addr,
 std::string CGUIScrollableMemoryLabelBox::FormatMemoryLine(const uint8_t *buffer, uint32_t addr, uint32_t bytes) const{
     std::stringstream Stream;
 
-    Stream<<' ';
+    if (std::static_pointer_cast<CMemoryControllerDevice>(DMemoryDevice)->FindWatchpoint({addr, bytes})){
+        Stream<<'@';
+    } else {
+        Stream<<' ';
+    }
     Stream<<std::setfill('0') << std::setw(8) << std::hex << addr;
     Stream<<":";
     for(uint32_t Index = 0; Index < bytes; Index++){

--- a/riscv-sim/src/GUIScrollableMemoryLabelBox.cpp
+++ b/riscv-sim/src/GUIScrollableMemoryLabelBox.cpp
@@ -114,7 +114,7 @@ void CGUIScrollableMemoryLabelBox::UpdateMemoryLine(size_t index, uint32_t addr,
     DLabels[index]->SetText(FormatMemoryLine(DMemoryDevice->LoadData(addr,bytes),addr,bytes));
 }
 
-std::string CGUIScrollableMemoryLabelBox::FormatMemoryLine(const uint8_t *buffer, uint32_t addr, uint32_t bytes){
+std::string CGUIScrollableMemoryLabelBox::FormatMemoryLine(const uint8_t *buffer, uint32_t addr, uint32_t bytes) const{
     std::stringstream Stream;
 
     Stream<<' ';

--- a/riscv-sim/src/GUIScrollableMemoryLabelBox.cpp
+++ b/riscv-sim/src/GUIScrollableMemoryLabelBox.cpp
@@ -103,6 +103,7 @@ void CGUIScrollableMemoryLabelBox::UpdateMemoryLine(size_t index, uint32_t addr,
 std::string CGUIScrollableMemoryLabelBox::FormatMemoryLine(const uint8_t *buffer, uint32_t addr, uint32_t bytes){
     std::stringstream Stream;
 
+    Stream<<' ';
     Stream<<std::setfill('0') << std::setw(8) << std::hex << addr;
     Stream<<":";
     for(uint32_t Index = 0; Index < bytes; Index++){

--- a/riscv-sim/src/GUIScrollableMemoryLabelBox.cpp
+++ b/riscv-sim/src/GUIScrollableMemoryLabelBox.cpp
@@ -172,7 +172,7 @@ void CGUIScrollableMemoryLabelBox::UpdateBufferedLine(size_t index, const std::s
 }
 
 void CGUIScrollableMemoryLabelBox::SetWidthCharacters(int chars){
-    int MinWidth = DBytesPerLine * 4 + 11;
+    int MinWidth = DBytesPerLine * 4 + 12;
     if(chars >= MinWidth){
         CGUIScrollableLabelBox::SetWidthCharacters(chars);
     }

--- a/riscv-sim/src/GUIScrollableMemoryLabelBox.cpp
+++ b/riscv-sim/src/GUIScrollableMemoryLabelBox.cpp
@@ -148,7 +148,7 @@ size_t CGUIScrollableMemoryLabelBox::GetBufferedLineCount() const{
 std::string CGUIScrollableMemoryLabelBox::GetBufferedLine(size_t index) const{
     size_t MemoryIndex = 0;
     uint32_t CurrentAddress;
-    size_t CurrentLine = GetBaseLine();
+    size_t CurrentLine = index;
 
     if(!DAscending){
         CurrentLine = DBufferedLineCount - CurrentLine - 1;

--- a/riscv-sim/src/GUIScrollableMemoryLabelBox.cpp
+++ b/riscv-sim/src/GUIScrollableMemoryLabelBox.cpp
@@ -46,6 +46,20 @@ bool CGUIScrollableMemoryLabelBox::LineIndexToBaseAddressMemoryIndex(size_t inde
     return false;
 }
 
+size_t CGUIScrollableMemoryLabelBox::AddressToMemoryIndex(uint32_t addr) const{
+    for(size_t Index = 0; Index < DMemoryLines.size(); Index++){
+        if(addr < DMemoryBases[Index]){
+            return Index - 1;
+        }
+    }
+    return DMemoryLines.size() - 1;
+}
+
+uint32_t CGUIScrollableMemoryLabelBox::AddressMemoryIndexToLineBytes(uint32_t addr, size_t mem_index) const{
+    uint32_t NextAddress = addr + DBytesPerLine;
+    return NextAddress > DMemoryBases[mem_index] + DMemorySizes[mem_index] ? (DMemoryBases[mem_index] + DMemorySizes[mem_index]) - addr : DBytesPerLine;
+}
+
 void CGUIScrollableMemoryLabelBox::UpdateBaseLine(){
     uint32_t LineCount = 0;
     for(size_t Index = 0; Index < DMemoryBases.size(); Index++){
@@ -157,8 +171,7 @@ std::string CGUIScrollableMemoryLabelBox::GetBufferedLine(size_t index) const{
 
     LineIndexToBaseAddressMemoryIndex(CurrentLine,CurrentAddress,MemoryIndex);
 
-    uint32_t NextAddress = CurrentAddress + DBytesPerLine;
-    uint32_t Bytes = NextAddress > DMemoryBases[MemoryIndex] + DMemorySizes[MemoryIndex] ? (DMemoryBases[MemoryIndex] + DMemorySizes[MemoryIndex]) - CurrentAddress : DBytesPerLine;
+    uint32_t Bytes = AddressMemoryIndexToLineBytes(CurrentAddress, MemoryIndex);
 
     return FormatMemoryLine(DMemoryDevice->LoadData(CurrentAddress,Bytes), CurrentAddress, Bytes);
 }

--- a/riscv-sim/src/GUIScrollableMemoryLabelBox.cpp
+++ b/riscv-sim/src/GUIScrollableMemoryLabelBox.cpp
@@ -172,7 +172,6 @@ std::string CGUIScrollableMemoryLabelBox::GetBufferedLine(size_t index) const{
 
     if(!DAscending){
         CurrentLine = DBufferedLineCount - CurrentLine - 1;
-        CurrentLine = CurrentLine < GetLineCount() ? 0 : CurrentLine - GetLineCount();
     }
 
     LineIndexToBaseAddressMemoryIndex(CurrentLine,CurrentAddress,MemoryIndex);

--- a/riscv-sim/src/GUIScrollableMemoryLabelBox.cpp
+++ b/riscv-sim/src/GUIScrollableMemoryLabelBox.cpp
@@ -200,3 +200,7 @@ void CGUIScrollableMemoryLabelBox::SetWidthCharacters(int chars){
 void CGUIScrollableMemoryLabelBox::Refresh(){
     RefreshLabels();
 }
+
+void CGUIScrollableMemoryLabelBox::SetBaseAddress(uint32_t addr){
+    SetBaseAddress(addr, true);
+}

--- a/riscv-sim/src/GUIScrollableMemoryLabelBox.cpp
+++ b/riscv-sim/src/GUIScrollableMemoryLabelBox.cpp
@@ -168,7 +168,7 @@ void CGUIScrollableMemoryLabelBox::SetBufferedLines(const std::vector< std::stri
 }
 
 void CGUIScrollableMemoryLabelBox::UpdateBufferedLine(size_t index, const std::string &line){
-    
+    DLabels[index - DBaseLine]->SetText(line);
 }
 
 void CGUIScrollableMemoryLabelBox::SetWidthCharacters(int chars){

--- a/riscv-sim/src/MemoryControllerDevice.cpp
+++ b/riscv-sim/src/MemoryControllerDevice.cpp
@@ -44,6 +44,10 @@ void CMemoryControllerDevice::RemoveWatchpoint(CMemoryRange mem_range){
     DWatchpoints.erase(mem_range);
 }
 
+bool CMemoryControllerDevice::FindWatchpoint(CMemoryRange mem_range) const{
+    return DWatchpoints.end() != DWatchpoints.find(mem_range);
+}
+
 bool CMemoryControllerDevice::AttachDevice(std::shared_ptr< CMemoryDevice > device, uint32_t addr){
     uint32_t Offset = addr - DBaseAddress;
     if(DMemorySize && DMemorySize <= Offset){

--- a/riscv-sim/src/MemoryControllerDevice.cpp
+++ b/riscv-sim/src/MemoryControllerDevice.cpp
@@ -7,14 +7,21 @@ static const uint32_t CMemoryControllerDeviceIndices = 1<<CMemoryControllerDevic
 static const uint32_t CMemoryControllerDeviceIndexMask = CMemoryControllerDeviceIndices - 1;
 
 
-CMemoryControllerDevice::CMemoryControllerDevice(uint32_t bits){
+CMemoryControllerDevice::CMemoryControllerDevice(uint32_t bits, uint32_t *watchpoint_address, bool *watchpoint_hit){
     DBaseAddress = 0;
     DMemorySize = 32 > bits ? 1<<bits : 0;
     DShiftBits = bits - CMemoryControllerDeviceIndexBits;
     DSubDevices.resize(CMemoryControllerDeviceIndices);
+
+    WatchpointHit = watchpoint_hit;
+    WatchpointAddress = watchpoint_address;
 }
 
 std::shared_ptr<CMemoryDevice> CMemoryControllerDevice::AccessAddress(uint32_t addr, uint32_t size, bool debug_load){
+    if (!debug_load && FindWatchpoint({addr, size})) {
+        *WatchpointHit = true;
+        *WatchpointAddress = addr;
+    }
     uint32_t Offset = addr - DBaseAddress;
     uint32_t Index = (Offset>>DShiftBits) & CMemoryControllerDeviceIndexMask;
     
@@ -76,7 +83,7 @@ bool CMemoryControllerDevice::AttachDevice(std::shared_ptr< CMemoryDevice > devi
         return false;
     }
     uint32_t NewBase = addr & ((~(uint32_t)0)<<NewBits);
-    auto NewMemoryController = std::make_shared<CMemoryControllerDevice>(NewBits);
+    auto NewMemoryController = std::make_shared<CMemoryControllerDevice>(NewBits, WatchpointAddress, WatchpointHit);
     NewMemoryController->BaseAddress(NewBase);
     if(!NewMemoryController->AttachDevice(device,addr)){
         return false;

--- a/riscv-sim/src/MemoryControllerDevice.cpp
+++ b/riscv-sim/src/MemoryControllerDevice.cpp
@@ -1,4 +1,5 @@
 #include "MemoryControllerDevice.h"
+#include "MemoryRange.h"
 #include <cstdio>
 
 static const uint32_t CMemoryControllerDeviceIndexBits = 4;
@@ -29,6 +30,14 @@ void CMemoryControllerDevice::DumpData(std::ostream &out, uint32_t saddr, uint32
             SubDevice->DumpData(out,saddr,eaddr);
         }
     }
+}
+
+void CMemoryControllerDevice::AddWatchpoint(CMemoryRange mem_range){
+    DWatchpoints.insert(mem_range);
+}
+
+void CMemoryControllerDevice::RemoveWatchpoint(CMemoryRange mem_range){
+    DWatchpoints.erase(mem_range);
 }
 
 bool CMemoryControllerDevice::AttachDevice(std::shared_ptr< CMemoryDevice > device, uint32_t addr){

--- a/riscv-sim/src/MemoryControllerDevice.cpp
+++ b/riscv-sim/src/MemoryControllerDevice.cpp
@@ -14,7 +14,7 @@ CMemoryControllerDevice::CMemoryControllerDevice(uint32_t bits){
     DSubDevices.resize(CMemoryControllerDeviceIndices);
 }
 
-std::shared_ptr<CMemoryDevice> CMemoryControllerDevice::AccessAddress(uint32_t addr, uint32_t size){
+std::shared_ptr<CMemoryDevice> CMemoryControllerDevice::AccessAddress(uint32_t addr, uint32_t size, bool debug_load){
     uint32_t Offset = addr - DBaseAddress;
     uint32_t Index = (Offset>>DShiftBits) & CMemoryControllerDeviceIndexMask;
     
@@ -121,9 +121,9 @@ void CMemoryControllerDevice::StoreUINT64(uint32_t addr, uint64_t val){
 }
 
 const uint8_t *CMemoryControllerDevice::LoadData(uint32_t addr, uint32_t size){
-    return AccessAddress(addr, size)->LoadData(addr, size);
+  return AccessAddress(addr, size, true)->LoadData(addr, size);
 }
 
 void CMemoryControllerDevice::StoreData(uint32_t addr, const uint8_t *src, uint32_t size){
-    AccessAddress(addr, size)->StoreData(addr, src, size);
+  AccessAddress(addr, size, true)->StoreData(addr, src, size);
 }

--- a/riscv-sim/src/MemoryControllerDevice.cpp
+++ b/riscv-sim/src/MemoryControllerDevice.cpp
@@ -32,6 +32,10 @@ void CMemoryControllerDevice::DumpData(std::ostream &out, uint32_t saddr, uint32
     }
 }
 
+void CMemoryControllerDevice::ClearWatchpoints(){
+    DWatchpoints.clear();
+}
+
 void CMemoryControllerDevice::AddWatchpoint(CMemoryRange mem_range){
     DWatchpoints.insert(mem_range);
 }

--- a/riscv-sim/src/MemoryRange.cpp
+++ b/riscv-sim/src/MemoryRange.cpp
@@ -1,0 +1,5 @@
+#include "MemoryRange.h"
+
+bool CMemoryRange::operator<(const CMemoryRange & rhs) const {
+    return (addr + range - 1) < rhs.addr;
+}

--- a/riscv-sim/src/RISCVConsole.cpp
+++ b/riscv-sim/src/RISCVConsole.cpp
@@ -1,6 +1,7 @@
 #include "RISCVConsole.h"
 #include "MemoryControllerDevice.h"
 #include "RAMMemoryDevice.h"
+#include "MemoryRange.h"
 #include "RISCVBlockInstructionCache.h"
 #include "GraphicFactory.h"
 #include "Path.h"
@@ -675,6 +676,24 @@ void CRISCVConsole::RemoveBreakpoint(uint32_t addr){
     auto CurrentState = DSystemCommand.load();
     SystemStop();
     DBreakpoints.erase(addr);
+    if(CurrentState == to_underlying(EThreadState::Run)){
+        SystemRun();
+    }
+}
+
+void CRISCVConsole::AddWatchpoint(CMemoryRange mem_range){
+    auto CurrentState = DSystemCommand.load();
+    SystemStop();
+    std::static_pointer_cast<CMemoryControllerDevice>(DMemoryController)->AddWatchpoint(mem_range);
+    if(CurrentState == to_underlying(EThreadState::Run)){
+        SystemRun();
+    }
+}
+
+void CRISCVConsole::RemoveWatchpoint(CMemoryRange mem_range){
+    auto CurrentState = DSystemCommand.load();
+    SystemStop();
+    std::static_pointer_cast<CMemoryControllerDevice>(DMemoryController)->RemoveWatchpoint(mem_range);
     if(CurrentState == to_underlying(EThreadState::Run)){
         SystemRun();
     }

--- a/riscv-sim/src/RISCVConsole.cpp
+++ b/riscv-sim/src/RISCVConsole.cpp
@@ -731,3 +731,7 @@ void CRISCVConsole::ClearBreakpoints(){
         SystemRun();
     }
 }
+
+uint32_t CRISCVConsole::GetWatchPointAddress(){
+    return WatchpointAddress;
+}

--- a/riscv-sim/src/RISCVConsoleApplication.cpp
+++ b/riscv-sim/src/RISCVConsoleApplication.cpp
@@ -586,6 +586,11 @@ bool CRISCVConsoleApplication::InstructionBoxButtonEvent(std::shared_ptr<CGUIScr
 }
 
 bool CRISCVConsoleApplication::MemoryBoxButtonEvent(std::shared_ptr<CGUIScrollableLineBox> widget, SGUIButtonEvent &event, size_t line){
+    if(event.DType.IsDoubleButtonPress()){
+        auto Line = DDebugMemory->GetBufferedLine(line);
+        Line[0] = '@';
+        DDebugMemory->UpdateBufferedLine(line, Line);
+    }
     return true;
 }
 

--- a/riscv-sim/src/RISCVConsoleApplication.cpp
+++ b/riscv-sim/src/RISCVConsoleApplication.cpp
@@ -530,6 +530,7 @@ bool CRISCVConsoleApplication::ClearButtonClickEvent(std::shared_ptr<CGUIWidget>
     }
 
     std::static_pointer_cast<CMemoryControllerDevice>(DRISCVConsole->Memory())->ClearWatchpoints();
+    DDebugMemory->Refresh();
 
     DRISCVConsole->ClearBreakpoints();
     return true;

--- a/riscv-sim/src/RISCVConsoleApplication.cpp
+++ b/riscv-sim/src/RISCVConsoleApplication.cpp
@@ -166,10 +166,16 @@ void CRISCVConsoleApplication::BreakpointEventCallback(CRISCVConsoleBreakpointCa
     App->BreakpointEvent();
 }
 
+void CRISCVConsoleApplication::WatchpointEventCallback(CRISCVConsoleBreakpointCalldata data){
+    CRISCVConsoleApplication *App = static_cast<CRISCVConsoleApplication *>(data);
+    App->WatchpointEvent();
+}
+
 void CRISCVConsoleApplication::Activate(){
     DRISCVConsole->SetDebugMode(DDebugMode);
     if(DDebugMode){
         DRISCVConsole->SetBreakcpointCallback(this,BreakpointEventCallback);
+        DRISCVConsole->SetWatchpointCallback(this,WatchpointEventCallback);
     }
     DMainWindow = DApplication->NewWindow();
     DMainWindow->SetDeleteEventCallback(this, MainWindowDeleteEventCallback);
@@ -621,6 +627,9 @@ bool CRISCVConsoleApplication::InstructionBoxScrollEvent(std::shared_ptr<CGUIScr
 void CRISCVConsoleApplication::BreakpointEvent(){
     DFollowingInstruction = true;
     DDebugRunButton->SetActive(false);
+}
+
+void CRISCVConsoleApplication::WatchpointEvent(){
 }
 
 std::shared_ptr< CRISCVConsoleApplication > CRISCVConsoleApplication::Instance(const std::string &appname){

--- a/riscv-sim/src/RISCVConsoleApplication.cpp
+++ b/riscv-sim/src/RISCVConsoleApplication.cpp
@@ -593,6 +593,14 @@ bool CRISCVConsoleApplication::MemoryBoxButtonEvent(std::shared_ptr<CGUIScrollab
         if(ParseMemoryLine(line,Address,Watchpoint)){
             Line[0] = Watchpoint ? ' ' : '@';
             DDebugMemory->UpdateBufferedLine(line, Line);
+
+            uint32_t Bytes = DDebugMemory->AddressMemoryIndexToLineBytes(Address, DDebugMemory->AddressToMemoryIndex(Address));
+
+            if(Watchpoint){
+	        DRISCVConsole->RemoveWatchpoint({Address, Bytes});
+            } else {
+                DRISCVConsole->AddWatchpoint({Address, Bytes});
+	    }
         }
     }
     return true;

--- a/riscv-sim/src/RISCVConsoleApplication.cpp
+++ b/riscv-sim/src/RISCVConsoleApplication.cpp
@@ -151,7 +151,8 @@ bool CRISCVConsoleApplication::InstructionBoxButtonEventCallback(std::shared_ptr
 }
 
 bool CRISCVConsoleApplication::MemoryBoxButtonEventCallback(std::shared_ptr<CGUIScrollableLineBox> widget, SGUIButtonEvent &event, size_t line, TGUICalldata data){
-    return 0;
+    CRISCVConsoleApplication *App = static_cast<CRISCVConsoleApplication *>(data);
+    return App->MemoryBoxButtonEvent(widget,event,line);
 }
 
 bool CRISCVConsoleApplication::InstructionBoxScrollEventCallback(std::shared_ptr<CGUIScrollableLineBox> widget, TGUICalldata data){
@@ -581,6 +582,10 @@ bool CRISCVConsoleApplication::InstructionBoxButtonEvent(std::shared_ptr<CGUIScr
             }
         }
     }
+    return true;
+}
+
+bool CRISCVConsoleApplication::MemoryBoxButtonEvent(std::shared_ptr<CGUIScrollableLineBox> widget, SGUIButtonEvent &event, size_t line){
     return true;
 }
 

--- a/riscv-sim/src/RISCVConsoleApplication.cpp
+++ b/riscv-sim/src/RISCVConsoleApplication.cpp
@@ -1,4 +1,5 @@
 #include "RISCVConsoleApplication.h"
+#include "MemoryControllerDevice.h"
 #include "FileDataSink.h"
 #include "FileDataSource.h"
 #include "Path.h"
@@ -527,6 +528,9 @@ bool CRISCVConsoleApplication::ClearButtonClickEvent(std::shared_ptr<CGUIWidget>
         Line[0] = ' ';
         DDebugInstructions->UpdateBufferedLine(LineIndex, Line);
     }
+
+    std::static_pointer_cast<CMemoryControllerDevice>(DRISCVConsole->Memory())->ClearWatchpoints();
+
     DRISCVConsole->ClearBreakpoints();
     return true;
 }

--- a/riscv-sim/src/RISCVConsoleApplication.cpp
+++ b/riscv-sim/src/RISCVConsoleApplication.cpp
@@ -150,6 +150,10 @@ bool CRISCVConsoleApplication::InstructionBoxButtonEventCallback(std::shared_ptr
     return App->InstructionBoxButtonEvent(widget,event,line);
 }
 
+bool CRISCVConsoleApplication::MemoryBoxButtonEventCallback(std::shared_ptr<CGUIScrollableLineBox> widget, SGUIButtonEvent &event, size_t line, TGUICalldata data){
+    return 0;
+}
+
 bool CRISCVConsoleApplication::InstructionBoxScrollEventCallback(std::shared_ptr<CGUIScrollableLineBox> widget, TGUICalldata data){
     CRISCVConsoleApplication *App = static_cast<CRISCVConsoleApplication *>(data);
     return App->InstructionBoxScrollEvent(widget);
@@ -934,6 +938,7 @@ void CRISCVConsoleApplication::CreateDebugMemoryWidgets(){
     };
     DDebugMemory = std::make_shared<CGUIScrollableMemoryLabelBox>(DRISCVConsole->Memory(), MemoryRegions);
     DDebugMemory->SetLineCount(GetMemoryLineCount());
+    DDebugMemory->SetButtonPressEventCallback(this,MemoryBoxButtonEventCallback);
 }
 
 bool CRISCVConsoleApplication::ParseInstructionLine(size_t line, uint32_t &addr, bool &breakpoint){

--- a/riscv-sim/src/RISCVConsoleApplication.cpp
+++ b/riscv-sim/src/RISCVConsoleApplication.cpp
@@ -630,6 +630,7 @@ void CRISCVConsoleApplication::BreakpointEvent(){
 }
 
 void CRISCVConsoleApplication::WatchpointEvent(){
+    DDebugMemory->SetBaseAddress(DRISCVConsole->GetWatchPointAddress());
 }
 
 std::shared_ptr< CRISCVConsoleApplication > CRISCVConsoleApplication::Instance(const std::string &appname){


### PR DESCRIPTION
Hi, I worked on this briefly a while back and forgot about it, but figured I'd offer up the changes I made to see if you would be interested. If so, I can do a little clean up and  a lot more testing (I didn't test much since I am unsure if you'd even want the additions), so please don't accept this as-is.

### Overview

This pull request adds the functionality of memory watchpoints to the simulator. That is, in debug mode, a user can specify a memory address which any access to will cause the machine to pause executing, similar to a breakpoint. The logic for this sits within the memory controller. 

To use, the user must run the simulator in debug mode. A double click on any line in the MemoryLabelBox will add a watchpoint for that line. A watchpoint is indicated by a `@` symbol next to the line. A double click will subsequently remove the watchpoint.

<img width="611" alt="Screen Shot 2023-03-31 at 9 15 58 AM" src="https://user-images.githubusercontent.com/92571492/229064843-e985375e-144e-4652-94e1-a83878ca931d.png">

### Limitations
- Instructions are cached, so there is not a memory access on every instruction. Thus, it is not reliable to expect a memory fetch to cause a watchpoint to fire. While this lacks realism, in functionality it should not matter since a breakpoint can be used to replicate the behavior desired.
- Only a general watchpoint can be specified, not specifically for a read or write. The changes were made with this in mind, so it should be easy to add this functionality (if you so desire).
- The size of a memory region to watch is limited by the GUI interface. That is, a watchpoint is a added to a line by clicking that line in the memory box. It seemed like a decent amount of work to allow for more fine grained accesses. 